### PR TITLE
add profile + statements endpoints. configure CORS for FE client. add…

### DIFF
--- a/fmp_utils/mongo.py
+++ b/fmp_utils/mongo.py
@@ -1,0 +1,128 @@
+import os
+import logging
+import fmpsdk
+
+from fastapi import HTTPException
+from dotenv import load_dotenv
+from pymongo import UpdateOne
+from typing import Optional, List
+
+load_dotenv(".env.local")
+
+MONGODB_URI = os.getenv("MONGODB_URI")
+FMP_API_KEY = os.getenv("FMP_API_KEY")
+
+logger = logging.getLogger(__name__)
+
+if not MONGODB_URI:
+    raise ValueError("No MONGODB_URI found in environment variables!")
+if not FMP_API_KEY:
+    raise ValueError("No FMP_API_KEY found in environment variables!")
+
+def query_mongo_profile(collection, symbol: str) -> Optional[dict]:
+    return collection.find_one({"symbol": symbol})
+
+def query_mongo_statement(collection, symbol: str, statement_type: str) -> Optional[dict]:
+    # Build the Mongo query for financial statements
+    query = {"symbol": symbol}
+    if statement_type:
+        query["statementType"] = statement_type
+
+    # Attempt to find existing statements in Mongo
+    return list(collection.find(query))
+
+def fetch_fmp_profile(symbol: str) -> dict:
+    profile_data = fmpsdk.company_profile(apikey=FMP_API_KEY, symbol=symbol)
+
+    if not profile_data:
+        # FMP returned empty or error
+        raise HTTPException(status_code=404, detail=f"No FMP profile data found for {symbol}")
+
+    # Usually it's a list with a single dict
+    return profile_data[0]
+
+def fetch_fmp_statement(symbol: str, statement_type: str) -> dict:
+    # The fmpsdk has separate calls for each statement type
+    if statement_type == "income":
+        statements = fmpsdk.income_statement(apikey=FMP_API_KEY, symbol=symbol, limit=5)
+    elif statement_type == "balance":
+        statements = fmpsdk.balance_sheet_statement(apikey=FMP_API_KEY, symbol=symbol, limit=5)
+    elif statement_type == "cash_flow":
+        statements = fmpsdk.cash_flow_statement(apikey=FMP_API_KEY, symbol=symbol, limit=5)
+    else:
+        raise HTTPException(status_code=400, detail=f"Invalid statementType: {statement_type}")
+
+    if not statements:
+        raise HTTPException(status_code=404, detail=f"No FMP data for {statement_type} of {symbol}")
+    
+    return statements
+
+def upsert_symbol_data(collection, symbol: str, data: dict) -> None:
+    collection.update_one(
+        {"symbol": symbol},
+        {"$set": data},
+        upsert=True
+    )
+
+def get_profile(company_profiles_collection, symbol: str) -> dict:
+    """
+    Checks Mongo for data before calling FMP's company profile endpoint
+    If fetching from FMP, upserts into MongoDB.
+    Returns the profile as a dictionary.
+    """
+    profile_data = query_mongo_profile(company_profiles_collection, symbol)
+
+    if profile_data:
+        return profile_data
+    
+    profile_data = fetch_fmp_profile(symbol)
+    
+    upsert_symbol_data(company_profiles_collection, symbol, profile_data)
+
+    return profile_data
+
+def upsert_financial_data(collection, symbol: str, doc: str) -> None:
+        # Define unique query for upsert
+        query = {
+            "symbol": symbol,
+            "statementType": doc["statementType"],
+            "fiscalYear": doc["fiscalYear"],
+            "period": doc["period"]
+        }
+
+        # Upsert the entire doc
+        collection.update_one(query, {"$set": doc}, upsert=True)
+
+def get_statement(financial_statements_collection, symbol: str, statement_type: str) -> List[dict]:
+    """
+    Fetches the requested statement_type (income, balance, or cash_flow)
+    from FMP and upserts them into MongoDB.
+    Returns a list of the statements.
+    """
+    existing = query_mongo_statement(financial_statements_collection, symbol, statement_type)
+
+    if existing:
+        return existing
+    
+    data_list = fetch_fmp_statement(symbol, statement_type)
+
+    result_docs = []
+
+    for record in data_list:
+        # Convert the fmpsdk record (which is a dict) to a new dict so we can modify it
+        doc = dict(record)  # copy all fields (raw data)
+        doc["symbol"] = symbol
+        doc["statementType"] = statement_type
+
+        # Optional: Extract or standardize certain fields
+        # e.g. "calendarYear" => int
+        calendar_year = record.get("calendarYear")
+        if calendar_year and calendar_year.isdigit():
+            doc["fiscalYear"] = int(calendar_year)
+        else:
+            doc["fiscalYear"] = None
+
+        upsert_financial_data(financial_statements_collection, symbol, doc)
+        result_docs.append(doc)
+
+    return result_docs

--- a/main.py
+++ b/main.py
@@ -1,27 +1,46 @@
 # main.py
 
 import os
+import fmpsdk
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
+from typing import Optional, List
 from dotenv import load_dotenv
 from utils import get_mongo_client
-
+from fmp_utils import mongo
 
 # Load environment variables from .env.local
 load_dotenv(".env.local")
 
 # Retrieve MongoDB URI from environment
 MONGODB_URI = os.getenv("MONGODB_URI")
+FMP_API_KEY = os.getenv("FMP_API_KEY")
 if not MONGODB_URI:
     raise ValueError("No MONGODB_URI found in environment variables!")
+if not FMP_API_KEY:
+    raise ValueError("No FMP_API_KEY found in environment variables!")
 
 # Initialize the FastAPI app
 app = FastAPI()
 
+origins = ["http://localhost:3000"]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
 # Create a MongoDB client and specify the database/collection
 client = get_mongo_client(MONGODB_URI)
 db = client["fmp"]
+
 collection = db["traded_list"]
+company_profiles_collection = db["company_profiles"]
+financial_statements_collection = db["financial_statements"]
 
 # Example Pydantic model for creating items
 class Item(BaseModel):
@@ -67,3 +86,51 @@ def create_item(item: Item):
     if created_item:
         created_item["_id"] = str(created_item["_id"])
     return created_item
+
+@app.get("/profiles/{symbol}")
+def get_company_profile(symbol: str) -> dict:
+    doc = dict(mongo.get_profile(company_profiles_collection, symbol))
+
+    doc["_id"] = str(doc["_id"])
+
+    return doc
+
+@app.get("/financials/{symbol}")
+def get_financials(
+    symbol: str,
+    statement_type: Optional[str] = None
+) -> dict:
+    """
+    Fetch a company profile and matching financial statements, 
+    optionally filtered by statement type.
+    
+    Example usage:
+        GET /financials/AAPL
+        GET /financials/AAPL?statement_type=income
+        GET /financials/AAPL?statement_type=balance
+    """
+    # Get the profile in MongoDB
+    profile_doc = mongo.get_profile(company_profiles_collection, symbol)
+
+    if statement_type:
+        # Fetch just the requested statement type
+        statement_docs = mongo.get_statement(financial_statements_collection, symbol, statement_type)
+    else:
+        # statement_type not given => fetch all 3 types
+        all_types = ["income", "balance", "cash_flow"]
+        statement_docs = []
+        for stype in all_types:
+            statement_docs.extend(mongo.get_statement(financial_statements_collection, symbol, stype))
+
+    # Convert _id field to string for fastAPI compatibility
+    if "_id" in profile_doc:
+        profile_doc["_id"] = str(profile_doc["_id"])
+    for doc in statement_docs:
+        if "_id" in doc:
+            doc["_id"] = str(doc["_id"])
+
+    # Return response
+    return {
+        "profile": profile_doc,
+        "statements": statement_docs
+    }

--- a/main.py
+++ b/main.py
@@ -91,7 +91,8 @@ def create_item(item: Item):
 def get_company_profile(symbol: str) -> dict:
     doc = dict(mongo.get_profile(company_profiles_collection, symbol))
 
-    doc["_id"] = str(doc["_id"])
+    if("_id" in doc):
+        doc["_id"] = str(doc["_id"])
 
     return doc
 


### PR DESCRIPTION
Added two new endpoints:
- `/profiles/{symbol}`: for profile data
- `/financials/{symbol}`: for financial statements (cash_flow, income, balance)

Configured CORS to allow connecting a FE client from `http://localhost:3000`

Added a new fmp_utils directory that handles FMP fetches only if data is missing from Mongo. Any newly fetched data is stored in Mongo to reduce FMP calls.
