### PR TITLE
Omit profile from statements endpoint

### DIFF
--- a/main.py
+++ b/main.py
@@ -39,6 +39,7 @@ client = get_mongo_client(MONGODB_URI)
 db = client["fmp"]
 
 collection = db["traded_list"]
+notes_collection = db["notes"]
 company_profiles_collection = db["company_profiles"]
 financial_statements_collection = db["financial_statements"]
 
@@ -100,7 +101,7 @@ def get_company_profile(symbol: str) -> dict:
 def get_financials(
     symbol: str,
     statement_type: Optional[str] = None
-) -> dict:
+) -> List:
     """
     Fetch a company profile and matching financial statements, 
     optionally filtered by statement type.
@@ -110,9 +111,6 @@ def get_financials(
         GET /financials/AAPL?statement_type=income
         GET /financials/AAPL?statement_type=balance
     """
-    # Get the profile in MongoDB
-    profile_doc = mongo.get_profile(company_profiles_collection, symbol)
-
     if statement_type:
         # Fetch just the requested statement type
         statement_docs = mongo.get_statement(financial_statements_collection, symbol, statement_type)
@@ -124,14 +122,9 @@ def get_financials(
             statement_docs.extend(mongo.get_statement(financial_statements_collection, symbol, stype))
 
     # Convert _id field to string for fastAPI compatibility
-    if "_id" in profile_doc:
-        profile_doc["_id"] = str(profile_doc["_id"])
     for doc in statement_docs:
         if "_id" in doc:
             doc["_id"] = str(doc["_id"])
 
     # Return response
-    return {
-        "profile": profile_doc,
-        "statements": statement_docs
-    }
+    return statement_docs

--- a/main.py
+++ b/main.py
@@ -39,7 +39,6 @@ client = get_mongo_client(MONGODB_URI)
 db = client["fmp"]
 
 collection = db["traded_list"]
-notes_collection = db["notes"]
 company_profiles_collection = db["company_profiles"]
 financial_statements_collection = db["financial_statements"]
 
@@ -103,7 +102,7 @@ def get_financials(
     statement_type: Optional[str] = None
 ) -> List:
     """
-    Fetch a company profile and matching financial statements, 
+    Fetch the company financial statements, 
     optionally filtered by statement type.
     
     Example usage:


### PR DESCRIPTION
`@app.get("/financials/{symbol}")` now returns only financial statements. The company profile will no longer be provided by the `financials` endpoint. The profile can still be requested from `@app.get("/profiles/{symbol}")`